### PR TITLE
fix: add Collection ID to Items for pypgstac ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,9 @@
 
 ### Feat
 
-- first commit with license and developer setup
+- First commit with license and developer setup ([#1](https://github.com/hotosm/stactools-hotosm/pull/1))
+- Create STAC Collection and Items from existing catalog ([#2](https://github.com/hotosm/stactools-hotosm/pull/2))
+
+### Fixed
+
+- Include Collection ID in Items to support ingest via `pypgstac load` ([#3](https://github.com/hotosm/stactools-hotosm/pull/3))

--- a/src/stactools/hotosm/stac.py
+++ b/src/stactools/hotosm/stac.py
@@ -120,6 +120,7 @@ def create_item(oam_metadata: OamMetadata) -> Item:
     """
     item = Item(
         id=oam_metadata.id,
+        collection=COLLECTION_ID,
         geometry=oam_metadata.geojson,
         bbox=oam_metadata.bbox,
         datetime=None,
@@ -187,6 +188,14 @@ def create_item(oam_metadata: OamMetadata) -> Item:
 
     _add_projection_extension(item, ["image"])
     _add_alternate_assets(item)
+
+    item.add_link(
+        Link(
+            rel=RelType.COLLECTION,
+            media_type=MediaType.JSON,
+            target="collection.json",
+        )
+    )
 
     item.validate()
     return item

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -9,6 +9,7 @@ import rasterio
 from pystac.utils import str_to_datetime
 from rasterio.transform import from_bounds
 
+from stactools.hotosm.constants import COLLECTION_ID
 from stactools.hotosm.exceptions import AssetNotFoundError
 from stactools.hotosm.oam_metadata import OamMetadata
 from stactools.hotosm.stac import create_collection, create_item
@@ -54,6 +55,8 @@ def test_create_item(example_oam_image: OamMetadata):
     """Test Item creation."""
     item = create_item(example_oam_image)
     item.validate()
+
+    assert item.collection_id == COLLECTION_ID
 
     for datetime_prop in {"start_datetime", "end_datetime"}:
         assert isinstance(str_to_datetime(item.properties[datetime_prop]), dt.datetime)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Issue

Small followup to https://github.com/hotosm/OpenAerialMap/issues/175

## Describe this PR

When working to ingest these Items locally using `pypgstac load` I hit an issue where the loader didn't know what Collection these Items belong to. This PR adds that information with a dummy link to the Collection for STAC spec compliance. This link will be overwritten when served via STAC FastAPI

## Screenshots

![image](https://github.com/user-attachments/assets/49c9a2cb-c26d-46b6-801d-7ee3e9499360)

## Alternative Approaches Considered

We could also have,

* Ingested without Collection ID using bulk transactions endpoint
    * This is more work to facilitate versus the `pypgstac load items openaerialmap.ndjson --dsn <pgstac dsn>`
* Wrapped the `pypgstac` based ingestion process to add this Collection ID before inserting, creating a temporarily invalid STAC Item
    * This is unplanned, but it's how some other ingestion processes handle this issue

## Review Guide

Unit tests have been updated,

```
./scripts/test
```
