### PR TITLE
fix: extension publishing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Parse extension version
         id: prep
         run: |
-          extension_version=$(echo "$env.GITHUB_REF" | awk -F '/' '{ print $NF }' | sed 's/extension-//')
+          extension_version=$(echo ${{ env.GITHUB_REF }}" | awk -F '/' '{ print $NF }' | sed 's/extension-//')
           echo "EXTENSION_VERSION=${extension_version}" >> $GITHUB_ENV
 
       - name: Build GH Pages static files
         id: build
         run: |
-          site=site/oam/${extension_version}
+          site=site/oam/${EXTENSION_VERSION}
           mkdir -p $site
           cp stac-extension/json-schema/schema.json $site/schema.json
           # sigh - force Github Actions "upload-artifact" to keep directory structure

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Parse extension version
         id: prep
         run: |
+          # parse extension from version for tag ref like "refs/tags/extension-v0.1.0"
           extension_version=$(echo ${{ env.GITHUB_REF }}" | awk -F '/' '{ print $NF }' | sed 's/extension-//')
           echo "EXTENSION_VERSION=${extension_version}" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -14,7 +14,7 @@ jobs:
         id: prep
         run: |
           # parse extension from version for tag ref like "refs/tags/extension-v0.1.0"
-          extension_version=$(echo ${{ env.GITHUB_REF }}" | awk -F '/' '{ print $NF }' | sed 's/extension-//')
+          extension_version=$(echo $GITHUB_REF | awk -F '/' '{ print $NF }' | sed 's/extension-//')
           echo "EXTENSION_VERSION=${extension_version}" >> $GITHUB_ENV
 
       - name: Build GH Pages static files


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Describe this PR

This PR fixes (🤞) the extension publishing by making two changes,

* Fix how to get GITHUB_REF from envvar
* Use correct UPPER CASE NAME for `EXTENSION_VERSION` when adding into prefix path

Last PR had published it to `[root url]/oam/schema.json` because the envvar was lower cased, so hopefully this gets us there