### PR TITLE
feat: ingestion system CLI for syncing OAM and Maxar STAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Create STAC Collection and Items from existing catalog ([#2](https://github.com/hotosm/stactools-hotosm/pull/2))
 - Add "created" based on "uploaded_at" OAM metadata ([#4](https://github.com/hotosm/stactools-hotosm/pull/4))
 - Add functions to create OAM-flavored STAC from Maxar's open data catalog ([#5](https://github.com/hotosm/stactools-hotosm/pull/5))
+- Add CLI to perform batch synchronization of STAC against OAM API and Maxar's open data catalog ([#10](https://github.com/hotosm/stactools-hotosm/pull/10))
 
 ### Fixed
 

--- a/examples/STAC Ingest.ipynb
+++ b/examples/STAC Ingest.ipynb
@@ -2,12 +2,167 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1838b303-3db3-4ef6-bec6-b0777464853e",
+   "metadata": {},
+   "source": [
+    "# STAC Ingestion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d74dd82-92b6-4a06-8fbf-e84de24233f1",
+   "metadata": {},
+   "source": [
+    "## Ingest STAC via STAC API\n",
+    "\n",
+    "This section explores using the STAC API interfaces to ingest STAC Items using endpoints that implement the [\"transactions\" STAC API extension](https://github.com/stac-api-extensions/transaction).\n",
+    "\n",
+    "This section presumes you've started the notebook with a few environment variables defined for configuration settings,\n",
+    "\n",
+    "* `STAC_API_ROOT` is the URL to the root of your STAC API\n",
+    "* Basic authorization details (optional)\n",
+    "    * `STAC_API_USERNAME` is a user with permission to interact with the transaction endpoints\n",
+    "    * `STAC_API_PASSWORD` is the password for the username"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ed584bae-e794-43cb-bb25-eb4ac61f3bfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "from itertools import batched\n",
+    "from pathlib import Path\n",
+    "from urllib.parse import urljoin\n",
+    "\n",
+    "import pystac\n",
+    "import requests\n",
+    "import rustac\n",
+    "\n",
+    "STAC_API_ROOT = os.environ[\"STAC_API_ROOT\"]\n",
+    "if not STAC_API_ROOT.endswith(\"/\"):\n",
+    "    STAC_API_ROOT += \"/\"\n",
+    "\n",
+    "session = requests.Session()\n",
+    "\n",
+    "if (username := os.getenv(\"STAC_API_USERNAME\")) and (\n",
+    "    password := os.getenv(\"STAC_API_PASSWORD\")\n",
+    "):\n",
+    "    session.auth = (username, password)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "281417d9-9541-4d28-a579-525d1340e55d",
+   "metadata": {},
+   "source": [
+    "First, we need to ensure that our STAC Collection has been created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "06482788-c59f-48a0-9ca0-6481723d0931",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Collection id=openaerialmap>, <Collection id=maxar-opendata>]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collections = [pystac.read_file(path) for path in Path(\".\").glob(\"*collection.json\")]\n",
+    "collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e3c5da93-9b5d-4fd4-b22d-08901dda6c5b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created openaerialmap\n",
+      "Created maxar-opendata\n"
+     ]
+    }
+   ],
+   "source": [
+    "for collection in collections:\n",
+    "    r = session.post(urljoin(STAC_API_ROOT, \"collections\"), json=collection.to_dict())\n",
+    "    r.raise_for_status()\n",
+    "    print(f\"Created {collection.id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce6f1216-4ac6-4e63-a548-c98a45982d7f",
+   "metadata": {},
+   "source": [
+    "To help handle cases where the same STAC Item has already been added to our STAC Catalog, we're going to use the \"bulk items\" endpoint to easily \"upsert\" (insert or update) our STAC Items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "8af354a3-abfe-49fc-ad8d-0547d74680e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this may need to be tuned depending on the API's maximum supported request size\n",
+    "ITEM_CHUNKSIZE = 15"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "f1541389-8068-464d-ae8c-565faee9bbb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adding openaerialmap-20250512T180412.parquet to STAC Catalog\n",
+      "Adding maxar-opendata-20250513T092240.parquet to STAC Catalog\n"
+     ]
+    }
+   ],
+   "source": [
+    "for collection in collections:\n",
+    "    item_paths = sorted(Path(\".\").glob(f\"{collection.id}*.parquet\"))\n",
+    "    for item_path in item_paths:\n",
+    "        print(f\"Adding {item_path} to STAC Catalog\")\n",
+    "        item_collection = await rustac.read(str(item_path))\n",
+    "        for items in batched(item_collection[\"features\"], ITEM_CHUNKSIZE):\n",
+    "            items_by_id = {item[\"id\"]: item for item in items}\n",
+    "            r = session.post(\n",
+    "                urljoin(STAC_API_ROOT, f\"collections/{collection.id}/bulk_items\"),\n",
+    "                json={\"method\": \"upsert\", \"items\": items_by_id},\n",
+    "            )\n",
+    "            r.raise_for_status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77121587-4f5a-4e0a-8c06-5109594e84d0",
    "metadata": {},
    "source": [
-    "# Ingest STAC Into PgSTAC\n",
+    "## Ingest STAC Into PgSTAC via pypgstac\n",
     "\n",
-    "This notebook is an example of using `pypgstac` tools to load STAC Collections and Items produced from the other example notebooks into PgSTAC. Once in PgSTAC these data will be available through the STAC API.\n",
+    "This section is an example of using `pypgstac` tools to load STAC Collections and Items produced from the other example notebooks into PgSTAC. Once in PgSTAC these data will be available through the STAC API.\n",
     "\n",
     "This notebook assumes you have defined some environment variables for the PgSTAC database connection. If they are not defined this notebook uses defaults from the [eoAPI](https://github.com/developmentseed/eoapi) Docker Compose setup.\n",
     "\n",
@@ -27,7 +182,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
     "import os\n",
     "from pathlib import Path\n",
     "from typing import Iterator\n",
@@ -65,8 +219,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "8d59b759-acfb-4810-8fa2-ab68e7aaecae",
+   "execution_count": null,
+   "id": "643e20b4-4714-4130-bbc1-4b863d6b0cfa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 27,
    "id": "3d292846-f0e3-4e20-b963-e814486a1167",
    "metadata": {},
    "outputs": [
@@ -110,17 +264,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading Items from openaerialmap-20250501T142120.ndjson\n"
+      "Loading Items from openaerialmap-20250501T142120.ndjson\n",
+      "Loading Items from openaerialmap-20250506T175956.ndjson\n",
+      "Loading Items from openaerialmap-20250506T181630.ndjson\n"
      ]
     }
    ],
    "source": [
-    "oam_ndjson = sorted(Path(\".\").glob(\"openaerialmap-*.ndjson\"))[-1]\n",
-    "print(f\"Loading Items from {oam_ndjson}\")\n",
-    "loader.load_items(\n",
-    "    read_items_from_ndjson(oam_ndjson, \"openaerialmap\"),\n",
-    "    insert_mode=Methods.insert_ignore,\n",
-    ")"
+    "oam_ndjson_files = sorted(Path(\".\").glob(\"openaerialmap-*.ndjson\"))\n",
+    "\n",
+    "for oam_ndjson in oam_ndjson_files:\n",
+    "    print(f\"Loading Items from {oam_ndjson}\")\n",
+    "    loader.load_items(\n",
+    "        read_items_from_ndjson(oam_ndjson, \"openaerialmap\"),\n",
+    "        insert_mode=Methods.insert_ignore,\n",
+    "    )"
    ]
   },
   {
@@ -143,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 28,
    "id": "f79572d2-2f90-43c7-b9c8-5ec0a6502417",
    "metadata": {},
    "outputs": [
@@ -151,17 +309,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading Items from maxar-opendata-20250501T141434.ndjson\n"
+      "Loading Items from maxar-opendata-20250505T085548.ndjson\n"
      ]
     }
    ],
    "source": [
-    "maxar_ndjson = sorted(Path(\".\").glob(\"maxar-*.ndjson\"))[-1]\n",
-    "print(f\"Loading Items from {maxar_ndjson}\")\n",
-    "loader.load_items(\n",
-    "    read_items_from_ndjson(maxar_ndjson, \"maxar-opendata\"),\n",
-    "    insert_mode=Methods.insert_ignore,\n",
-    ")"
+    "maxar_ndjson_files = sorted(Path(\".\").glob(\"maxar-*.ndjson\"))\n",
+    "\n",
+    "for maxar_ndjson in maxar_ndjson_files:\n",
+    "    print(f\"Loading Items from {maxar_ndjson}\")\n",
+    "    loader.load_items(\n",
+    "        read_items_from_ndjson(maxar_ndjson, \"maxar-opendata\"),\n",
+    "        insert_mode=Methods.insert_ignore,\n",
+    "    )"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "rio-stac>=0.10.1",
 ]
 
+[project.scripts]
+hotosm = "stactools.hotosm.cli:main"
+
 [dependency-groups]
 dev = [
     "mypy>=1.15.0",
@@ -75,8 +78,9 @@ mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 namespace_packages = true
 
 [[tool.mypy.overrides]]
-module = ["rasterio.*", "rio_stac.stac"]
+module = ["pypgstac.db", "pypgstac.load", "rasterio.*", "rio_stac.stac"]
 follow_untyped_imports = true
+ignore_missing_imports = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ demo = [
     "rustac>=0.7.2",
     "pypgstac[psycopg]>=0.9.6",
 ]
+ingest = [
+    "click>=8.1.8",
+    "pypgstac>=0.9.6",
+]
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/src/stactools/hotosm/cli.py
+++ b/src/stactools/hotosm/cli.py
@@ -1,0 +1,180 @@
+"""Command line interface for OAM STAC creation and syncing."""
+
+import datetime as dt
+from typing import Any
+
+import click
+import pystac
+import requests
+from pypgstac.db import PgstacDB
+from pypgstac.load import Loader, Methods
+
+uploaded_since_sec = click.option(
+    "--uploaded-since",
+    type=float,
+    help="Find Items uploaded in last period provided in seconds.",
+)
+uploaded_after_dt = click.option(
+    "--uploaded-after",
+    type=click.DateTime(),
+    help="Find Items uploaded after this date (UTC).",
+)
+
+
+def parse_uploaded_since(
+    uploaded_since_sec: float | None,
+    uploaded_after_dt: dt.datetime | None,
+) -> dt.datetime:
+    """Parse mutually exclusive arguments for finding Items uploaded since some time."""
+    if (uploaded_after_dt is uploaded_since_sec) or (
+        uploaded_since_sec and uploaded_after_dt
+    ):
+        raise click.BadParameter(
+            "Must provide one of --uploaded-since or --uploaded-after"
+        )
+
+    if uploaded_since_sec is not None:
+        return dt.datetime.now(tz=dt.UTC) - dt.timedelta(seconds=uploaded_since_sec)
+
+    if uploaded_after_dt is not None:
+        return uploaded_after_dt.replace(tzinfo=dt.UTC)
+
+    raise click.BadParameter("Must provide one of --uploaded-since or --uploaded-after")
+
+
+def create_pgstac_from_ctx(
+    ctx: click.Context,
+    _: click.Parameter,
+    value: Any,
+) -> PgstacDB:
+    """Create DSN for PgSTAC."""
+    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(
+        user=ctx.params["pguser"],
+        password=ctx.params["pgpassword"],
+        host=ctx.params["pghost"],
+        port=ctx.params["pgport"],
+        database=value,
+    )
+    ctx.obj = ctx.obj or {}
+    ctx.obj["pgstac"] = PgstacDB(dsn)
+    return value
+
+
+pgstac_username = click.option(
+    "--pguser",
+    envvar="PGUSER",
+    help="Username for PgSTAC",
+    required=True,
+)
+pgstac_password = click.option(
+    "--pgpassword",
+    envvar="PGPASSWORD",
+    help="Password for PgSTAC",
+    required=True,
+)
+pgstac_host = click.option(
+    "--pghost",
+    envvar="PGHOST",
+    help="Host for PgSTAC",
+    required=True,
+)
+pgstac_port = click.option(
+    "--pgport",
+    envvar="PGPORT",
+    help="Port for PgSTAC",
+    required=True,
+)
+pgstac_database = click.option(
+    "--pgdatabase",
+    envvar="PGDATABASE",
+    help="Database for PgSTAC",
+    required=True,
+    callback=create_pgstac_from_ctx,
+)
+
+
+@click.group
+def main():
+    """STAC for Humanitarian OpenStreetMap Team OpenAerialMap."""
+
+
+@main.command()
+@uploaded_since_sec
+@uploaded_after_dt
+@pgstac_username
+@pgstac_password
+@pgstac_host
+@pgstac_port
+@pgstac_database
+@click.pass_context
+def sync_oam(
+    ctx: click.Context,
+    uploaded_since: float | None,
+    uploaded_after: dt.datetime | None,
+    **_pgstac_options: Any,
+):
+    """Sync new STAC Items from OAM metadata API."""
+    from stactools.hotosm.constants import COLLECTION_ID
+    from stactools.hotosm.oam_metadata_client import OamMetadataClient
+    from stactools.hotosm.stac import create_item
+
+    uploaded_after = parse_uploaded_since(uploaded_since, uploaded_after)
+    loader = Loader(ctx.obj["pgstac"])
+    click.echo(f"Looking for OAM metadata entities added since {uploaded_after}")
+
+    client = OamMetadataClient.new()
+    oam_meta = list(client.get_all_items(uploaded_after=uploaded_after))
+    click.echo(f"Found {len(oam_meta)} added since {uploaded_after}")
+
+    items_dict = []
+    for oam_meta_ in oam_meta:
+        item = create_item(oam_meta_.sanitize()).to_dict()
+        item["collection"] = COLLECTION_ID
+        items_dict.append(item)
+
+    loader.load_items(
+        iter(items_dict),
+        insert_mode=Methods.upsert,
+    )
+    click.echo(f"Completed ingesting {len(items_dict)} STAC Items")
+
+
+@main.command()
+@uploaded_since_sec
+@uploaded_after_dt
+@pgstac_username
+@pgstac_password
+@pgstac_host
+@pgstac_port
+@pgstac_database
+@click.pass_context
+def sync_maxar(
+    ctx: click.Context,
+    uploaded_since: float | None,
+    uploaded_after: dt.datetime | None,
+    **_pgstac_options: Any,
+) -> None:
+    """Sync new Maxar Items from the open data bucket."""
+    from stactools.hotosm.maxar.stac import COLLECTION_ID, create_item
+    from stactools.hotosm.maxar.sync import new_stac_items
+
+    uploaded_after = parse_uploaded_since(uploaded_since, uploaded_after)
+    loader = Loader(ctx.obj["pgstac"])
+    click.echo(f"Looking for STAC Items added since {uploaded_after}")
+
+    raw_items = list(
+        new_stac_items(pystac.stac_io.RetryStacIO(), requests.Session(), uploaded_after)
+    )
+    click.echo(f"Found {len(raw_items)} added since {uploaded_after}")
+
+    items_dict = []
+    for raw_item in raw_items:
+        item = create_item(raw_item).to_dict()
+        item["collection"] = COLLECTION_ID
+        items_dict.append(item)
+
+    loader.load_items(
+        iter(items_dict),
+        insert_mode=Methods.upsert,
+    )
+    click.echo(f"Completed ingesting {len(items_dict)} STAC Items")

--- a/src/stactools/hotosm/maxar/sync.py
+++ b/src/stactools/hotosm/maxar/sync.py
@@ -1,0 +1,49 @@
+"""Utilities for syncing Maxar STAC Items."""
+
+import datetime as dt
+import logging
+from typing import Iterator
+from urllib.parse import urljoin
+
+import pystac
+import requests
+
+logger = logging.getLogger(__name__)
+
+MAXAR_ROOT = "https://maxar-opendata.s3.amazonaws.com/events/"
+MAXAR_EVENT_INFO = "https://maxar-opendata.s3.amazonaws.com/event_info.json"
+
+
+def new_stac_items(
+    stac_io: pystac.StacIO,
+    session: requests.Session,
+    after: dt.datetime,
+) -> Iterator[pystac.Item]:
+    """Find Maxar STAC Items newer than some date.
+
+    This function helps subset the catalog by using the "event_info.json"
+    file in the root of the bucket that catalogs STAC Collections added
+    by event.
+
+    Args:
+        stac_io: PySTAC StacIO instance
+        session: requests Session object
+        after: Optionally, provide a filter to find Items added after this date.
+
+    Yields:
+        STAC Items
+    """
+    r = session.get(MAXAR_EVENT_INFO)
+    r.raise_for_status()
+    events = r.json()
+
+    for event in events:
+        event_date = dt.datetime.strptime(event["date"], "%Y-%m-%d").replace(
+            tzinfo=dt.UTC
+        )
+        if after is None or event_date >= after:
+            url = urljoin(MAXAR_ROOT, f"{event['s3_directory']}/collection.json")
+            collection = pystac.read_file(url, stac_io=stac_io)
+            assert isinstance(collection, pystac.Collection)
+            collection.remove_links(pystac.RelType.ROOT)
+            yield from collection.get_items(recursive=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,19 @@ def example_oam_meta_api_response() -> dict:
 
 
 @pytest.fixture
+def example_oam_meta_api_response_sortby_uploaded_at(
+    example_oam_meta_api_response: dict,
+) -> dict:
+    """Example OAM Metadata API response, sorted by uploaded date."""
+    example_oam_meta_api_response["results"] = sorted(
+        example_oam_meta_api_response["results"],
+        key=lambda result: result.get("uploaded_at", "0"),
+        reverse=True,
+    )
+    return example_oam_meta_api_response
+
+
+@pytest.fixture
 def example_oam_image(example_oam_metadata: OamMetadata, tmp_path: Path) -> OamMetadata:
     """Provision data for the example OAM metadata item."""
     data = np.random.randint(low=0, high=255, size=(3, 13, 42), dtype="uint8")

--- a/tests/maxar/test_sync.py
+++ b/tests/maxar/test_sync.py
@@ -1,0 +1,64 @@
+"""Test Maxar Item syncing."""
+
+import datetime as dt
+from unittest.mock import patch
+
+import pystac
+import requests
+import responses
+
+from stactools.hotosm.maxar.sync import MAXAR_EVENT_INFO, MAXAR_ROOT, new_stac_items
+
+
+@responses.activate
+def test_new_stac_items_filtering_none():
+    """Ensure older events are filtered out."""
+    session = requests.Session()
+    stac_io = pystac.stac_io.DefaultStacIO()
+
+    resp = responses.get(
+        url=MAXAR_EVENT_INFO,
+        json=[
+            {"date": "2020-01-01"},
+            {
+                "date": "2020-06-01",
+            },
+        ],
+    )
+    items = list(new_stac_items(stac_io, session, dt.datetime.now(tz=dt.UTC)))
+
+    assert len(items) == 0
+    assert resp.call_count == 1
+
+
+@responses.activate
+def test_new_stac_items_filtering():
+    """Ensure older events are filtered correctly."""
+    session = requests.Session()
+    stac_io = pystac.stac_io.DefaultStacIO()
+
+    resp = responses.get(
+        url=MAXAR_EVENT_INFO,
+        json=[
+            {"date": "2020-01-01"},
+            {
+                "date": "2025-05-01",
+                "s3_directory": "foo",
+            },
+        ],
+    )
+    collection = pystac.Collection(
+        id="test",
+        description="foo",
+        extent=None,
+    )
+    with patch("pystac.read_file", return_value=collection) as mock:
+        items = list(
+            new_stac_items(stac_io, session, dt.datetime(2025, 1, 1, tzinfo=dt.UTC))
+        )
+
+    assert len(items) == 0
+    assert resp.call_count == 1
+    mock.assert_called_once_with(
+        f"{MAXAR_ROOT.rstrip('/')}/foo/collection.json", stac_io=stac_io
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2070,6 +2070,10 @@ dev = [
     { name = "types-requests" },
     { name = "types-shapely" },
 ]
+ingest = [
+    { name = "click" },
+    { name = "pypgstac" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2094,6 +2098,10 @@ dev = [
     { name = "shapely", specifier = ">=2.1.0" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
     { name = "types-shapely", specifier = ">=2.0.0.20250326" },
+]
+ingest = [
+    { name = "click", specifier = ">=8.1.8" },
+    { name = "pypgstac", specifier = ">=0.9.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature

## Related Issue

Partially addresses, https://github.com/hotosm/OpenAerialMap/issues/182

## Describe this PR

This PR adds a lightweight method for keeping our STAC Catalog up to date with external imagery catalogs (the [OAM API](https://github.com/hotosm/oam-api) and [Maxar open data program](https://registry.opendata.aws/maxar-open-data/)). The PR adds,

* A function to find new Maxar open data program STAC Collections & Items
* A new set of arguments to the `OamMetadataClient` to support returning only recently uploaded imagery
* CLI programs to add Items from OAM API and Maxar's catalogs to our PgSTAC database using the `pypgstac.load.Loader` (i.e., direct DB connection)
    * The `--uploaded-after=<date>` option is intended for backfills that are either manual or where the scheduling system knows the last time a sync was performed (e.g., Airflow)
    * The `--uploaded-since=<seconds>` option is intended for simple automated backfills on some cron schedule (e.g., a scheduled Docker container run)
    * Naming suggestions are welcomed/encouraged!

## Screenshots

![image](https://github.com/user-attachments/assets/4dbeb5f1-caaa-4e2e-b6b4-cbe94c90f2dc)


## Alternative Approaches Considered

I also considered having just one "sync" command that requires selecting between the data sources since there's a lot of similar code. I'm still open to that, but I thought it was relatively less complicated to just have separate CLIs that look alike.

## Review Guide

I added unit tests for the changes to the "OAM API metadata client" and the "Maxar sync" functions. I haven't added unit tests for the CLI layer since a lot of that is just parsing CLI inputs, but you can try it out:

Assuming you're running [eoAPI](https://github.com/developmentseed/eoapi) via `docker compose up`,

Create a `.env` file or define the PgSTAC connection details via CLI or envvar,
```
PGUSER=username
PGPASSWORD=password
PGHOST=localhost
PGPORT=5439
PGDATABASE=postgis
```

Test out ingestions,
```shell
# Maxar
$ UV_ENV_FILE=.env uv run hotosm sync-maxar --uploaded-after 2025-01-01
Looking for STAC Items added since 2025-01-01 00:00:00+00:00
Found 525 added since 2025-01-01 00:00:00+00:00
Completed ingesting 525 STAC Items

# OAM
$ UV_ENV_FILE=.env uv run hotosm sync-oam --uploaded-since 86400
Looking for OAM metadata entities added since 2025-05-12 21:16:43.653923+00:00
Found 5 added since 2025-05-12 21:16:43.653923+00:00
Completed ingesting 5 STAC Items
```