### PR TITLE
fix: ensure all platform names are slug-like (lower cased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Include Collection ID in Items to support ingest via `pypgstac load` ([#3](https://github.com/hotosm/stactools-hotosm/pull/3))
 - Ensure acquisition start comes before end. Populate Item datetime or start/end_datetime properly ([#4](https://github.com/hotosm/stactools-hotosm/pull/4))
 - Use the same asset key ("visual") for visual assets in OAM and Maxar STAC Catalogs ([#10](https://github.com/hotosm/stactools-hotosm/pull/10))
+- Ensure `oam:platform_type` is lower cased ([#12](https://github.com/hotosm/stactools-hotosm/pull/12))

--- a/src/stactools/hotosm/oam_metadata.py
+++ b/src/stactools/hotosm/oam_metadata.py
@@ -88,8 +88,8 @@ class OamMetadata:
             self.license = self.license.replace(" ", "-")
 
     def _sanitize_platform(self):
-        """Sanitize platform (usually rewriting acronyms as uppercase)."""
-        self.platform = self.platform.lower()
+        """Sanitize platform to a slug representation."""
+        self.platform = self.platform.lower().replace("_", "-")
 
     def _sanitize_sensor(self):
         """Sanitize bad sensor values."""

--- a/src/stactools/hotosm/oam_metadata.py
+++ b/src/stactools/hotosm/oam_metadata.py
@@ -89,11 +89,7 @@ class OamMetadata:
 
     def _sanitize_platform(self):
         """Sanitize platform (usually rewriting acronyms as uppercase)."""
-        platform_transforms = {
-            "UAV": "uav",
-        }
-        if transformed := platform_transforms.get(self.platform.upper()):
-            self.platform = transformed
+        self.platform = self.platform.lower()
 
     def _sanitize_sensor(self):
         """Sanitize bad sensor values."""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Describe this PR

This PR helps ensure all of the platform names are valid since we've defined `oam:platform_type` as "slug" like (lower cased) values.